### PR TITLE
fix(jest): fix "jest/globals" is unknown

### DIFF
--- a/packages/eslint-config/jest.js
+++ b/packages/eslint-config/jest.js
@@ -1,7 +1,7 @@
 module.exports = {
   plugins: ['jest'],
   env: {
-    'jest/globals': true,
+    jest: true,
   },
   rules: {
     'max-nested-callbacks': 'off',


### PR DESCRIPTION
'jest/globals' env now is unknown for eslint. Used 'jest' instead like it was suggested here https://github.com/jest-community/eslint-plugin-jest/issues/44#issue-286150080